### PR TITLE
Makes all read counting dependent on args.verbose

### DIFF
--- a/scripts/matam_assembly.py
+++ b/scripts/matam_assembly.py
@@ -913,7 +913,7 @@ def main():
     # Get input reads number
     input_reads_nb = -1
 
-    if run_step:
+    if run_step and args.verbose:
         if input_fastq_extension in ('.fq', '.fastq'):
             input_fastq_line_nb = int(subprocess.check_output('wc -l {0}'.format(input_fastq_filepath), shell=True, bufsize=0).split()[0])
             if input_fastq_line_nb % 4 != 0:
@@ -962,11 +962,12 @@ def main():
     # Get selected reads number
     selected_reads_nb = -1
 
-    if input_fastq_extension in ('.fq', '.fastq'):
-        selected_fastq_line_nb = int(subprocess.check_output('wc -l {0}'.format(sortme_output_fastq_filepath), shell=True, bufsize=0).split()[0])
-        selected_reads_nb = selected_fastq_line_nb // 4
+    if args.verbose:
+        if input_fastq_extension in ('.fq', '.fastq'):
+            selected_fastq_line_nb = int(subprocess.check_output('wc -l {0}'.format(sortme_output_fastq_filepath), shell=True, bufsize=0).split()[0])
+            selected_reads_nb = selected_fastq_line_nb // 4
 
-    logger.info('Identified as marker: {} / {} reads ({:.2f}%)'.format(selected_reads_nb, input_reads_nb, selected_reads_nb*100.0/input_reads_nb))
+        logger.info('Identified as marker: {} / {} reads ({:.2f}%)'.format(selected_reads_nb, input_reads_nb, selected_reads_nb*100.0/input_reads_nb))
 
     # Tag tmp files for removal
     to_rm_filepath_list.append(sortme_output_basepath + '.log')
@@ -1059,11 +1060,12 @@ def main():
         # Tag tmp files for removal
         to_rm_filepath_list.append(ovgraphbuild_asqg_filepath)
 
-    # Get overlap graph stats
-    ovgraph_nodes_nb = int(subprocess.check_output('wc -l {0}'.format(ovgraphbuild_nodes_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
-    ovgraph_edges_nb = int(subprocess.check_output('wc -l {0}'.format(ovgraphbuild_edges_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
+    if args.verbose:
+        # Get overlap graph stats
+        ovgraph_nodes_nb = int(subprocess.check_output('wc -l {0}'.format(ovgraphbuild_nodes_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
+        ovgraph_edges_nb = int(subprocess.check_output('wc -l {0}'.format(ovgraphbuild_edges_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
 
-    logger.info('Overlap graph stats: {} nodes, {} edges'.format(ovgraph_nodes_nb, ovgraph_edges_nb))
+        logger.info('Overlap graph stats: {} nodes, {} edges'.format(ovgraph_nodes_nb, ovgraph_edges_nb))
 
     ###############################################
     # Graph compaction & Components identification
@@ -1098,15 +1100,16 @@ def main():
         #to_rm_filepath_list.append(ovgraphbuild_nodes_csv_filepath)
         #to_rm_filepath_list.append(ovgraphbuild_edges_csv_filepath)
 
-    # Get compressed graph stats
-    compressed_graph_nodes_nb = int(subprocess.check_output('wc -l {0}'.format(componentsearch_metanodes_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
-    compressed_graph_edges_nb = int(subprocess.check_output('wc -l {0}'.format(componentsearch_metaedges_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
-    compressed_graph_reads_nb = int(subprocess.check_output('cut -d ";" -f5 {0} | awk "\$1!=-1" | wc -l'.format(componentsearch_components_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
-    compressed_graph_excluded_reads_nb = ovgraph_nodes_nb - compressed_graph_reads_nb
-    excluded_reads_percent = compressed_graph_excluded_reads_nb * 100.0 / ovgraph_nodes_nb
-    components_nb = int(subprocess.check_output('cut -d ";" -f5 {0} | {1} | uniq | wc -l'.format(componentsearch_components_csv_filepath, sort_bin), shell=True).split()[0]) - 1
+    if args.verbose:
+        # Get compressed graph stats
+        compressed_graph_nodes_nb = int(subprocess.check_output('wc -l {0}'.format(componentsearch_metanodes_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
+        compressed_graph_edges_nb = int(subprocess.check_output('wc -l {0}'.format(componentsearch_metaedges_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
+        compressed_graph_reads_nb = int(subprocess.check_output('cut -d ";" -f5 {0} | awk "\$1!=-1" | wc -l'.format(componentsearch_components_csv_filepath), shell=True, bufsize=0).split()[0]) - 1
+        compressed_graph_excluded_reads_nb = ovgraph_nodes_nb - compressed_graph_reads_nb
+        excluded_reads_percent = compressed_graph_excluded_reads_nb * 100.0 / ovgraph_nodes_nb
+        components_nb = int(subprocess.check_output('cut -d ";" -f5 {0} | {1} | uniq | wc -l'.format(componentsearch_components_csv_filepath, sort_bin), shell=True).split()[0]) - 1
 
-    logger.info('Compressed graph: {} components'.format(components_nb))
+        logger.info('Compressed graph: {} components'.format(components_nb))
 
     ################
     # LCA labelling


### PR DESCRIPTION
On our HPC Cluster with a shared networked filesystem and 1000+ matam jobs running at the same time our filesystem was saturated due to the many `wc -l` subprocesses.

By looking at the `matam_assembly.py` script we realized that all the read counting done with `wc -l` is only used for logging purposes and does not actually affect any computation. That's why we decided to make it optional based on `args.verbose`.